### PR TITLE
fix(ci): remove # from issue id in branch naming convention

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -5,7 +5,9 @@
 branch=`git rev-parse --abbrev-ref HEAD`
 
 # Extract issue from branch name (if exists)
-issue=$(echo $branch | sed -nE 's,[a-z0-9/-]+#([0-9])-.+,\1,p')
+regex=".*-([0-9]*)-.*"
+[[ $branch =~ $regex ]]
+issue="${BASH_REMATCH[1]}"
 
 # If $issue was found in branch and isn't found in commit message, append to end of commit message
 if [ ! -z $issue ] && ! grep -q $issue $1 

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -10,10 +10,10 @@ BRANCH_TYPES="feat|fix|tmp"
 MIN_BRANCH_LENGTH=5
 MAX_BRANCH_LENGTH=50
 
-valid_branch_regex="^($BRANCH_TYPES)\/[a-z0-9#-]{$MIN_BRANCH_LENGTH,$MAX_BRANCH_LENGTH}$"
+valid_branch_regex="^($BRANCH_TYPES)\/[a-z0-9-]{$MIN_BRANCH_LENGTH,$MAX_BRANCH_LENGTH}$"
 branch_naming_convention="Branch naming convention
 
-               [type*]/[group]-#[issue]-[description*]
+               [type*]/[group]-[issue]-[description*]
 
    - type: task type ($BRANCH_TYPES)
    - group (optional): task group
@@ -28,7 +28,7 @@ if [ "$branch" = "main" ]; then
   echo "❌ ${RED}Forbidden to commit to main branch. Please create branch and work there.${NC}
   $branch_naming_convention
    Example            
-                    git checkout -b feat/ui-#12-add-dark-mode\n"
+                    git checkout -b feat/ui-12-add-dark-mode\n"
   exit 1
 fi
 
@@ -38,7 +38,7 @@ then
     echo "❌ ${RED}Invalid branch name. Please rename your branch adhearing to the following convention.${NC}
    $branch_naming_convention
     Example
-                          git branch -m feat/ui-#12-add-dark-mode\n"
+                          git branch -m feat/ui-12-add-dark-mode\n"
     exit 1
 fi
 


### PR DESCRIPTION
Including # in the issue id in the branch name was breaking the PR url shown in the console. The # is URL encoded and isn't automatically decoded so the PR doesn't automatically show the PR as merging the relevant branch into main.